### PR TITLE
Allowing Mailbox/Folder Manipulation Via Client

### DIFF
--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -1,0 +1,64 @@
+'use strict';
+
+module.exports = function(connection, parsed, data, callback) {
+
+	if (!parsed.attributes ||
+		parsed.attributes.length != 1 ||
+		!parsed.attributes[0]
+	) {
+
+		connection.send({
+			tag: parsed.tag,
+			command: 'BAD',
+			attributes:[
+				{type: 'TEXT', value: 'CREATE expects 1 mailbox name'}
+			]
+		}, 'INVALID COMMAND', parsed, data);
+		callback();
+	}
+
+	if (['Authenticated', 'Selected'].indexOf(connection.state) < 0) {
+		connection.send({
+			tag: parsed.tag,
+			command: 'BAD',
+			attributes:[
+				{type: 'TEXT', value: 'Log in first'}
+			]
+		}, 'CREATE FAILED', parsed, data);
+		callback();
+	}
+
+	var path = parsed.attributes[0].value,
+		mailbox = connection.getMailbox(path);
+
+
+	if (mailbox) {
+		connection.send({
+			tag: parsed.tag,
+			command: 'NO',
+			attributes:[
+				{type: 'TEXT', value: 'Mailbox already exists!'}
+			]
+		}, 'CREATE FAILED', parsed, data);
+		callback();
+	}
+
+	connection.storage.create_folder(connection.user, path, function(){
+
+		connection.indexFolders(function(){
+
+			connection.send({
+				tag: parsed.tag,
+				command: 'OK',
+				attributes: [
+					{type: 'TEXT', value: 'completed'}
+				]
+			}, 'CREATE', parsed, data);
+			
+		});
+
+	})
+
+
+
+};

--- a/lib/commands/delete.js
+++ b/lib/commands/delete.js
@@ -11,7 +11,7 @@ module.exports = function(connection, parsed, data, callback) {
 			tag: parsed.tag,
 			command: 'BAD',
 			attributes:[
-				{type: 'TEXT', value: 'CREATE expects 1 mailbox name'}
+				{type: 'TEXT', value: 'DELETE expects 1 mailbox name'}
 			]
 		}, 'INVALID COMMAND', parsed, data);
 		callback();
@@ -26,7 +26,7 @@ module.exports = function(connection, parsed, data, callback) {
 			attributes:[
 				{type: 'TEXT', value: 'Log in first'}
 			]
-		}, 'CREATE FAILED', parsed, data);
+		}, 'DELETE FAILED', parsed, data);
 		callback();
 		return;
 
@@ -36,32 +36,44 @@ module.exports = function(connection, parsed, data, callback) {
 		mailbox = connection.getMailbox(path);
 
 
-	if (mailbox) {
+	if (!mailbox) {
 		connection.send({
 			tag: parsed.tag,
 			command: 'NO',
 			attributes:[
-				{type: 'TEXT', value: 'Mailbox already exists!'}
+				{type: 'TEXT', value: 'Mailbox does not exist!'}
 			]
-		}, 'CREATE FAILED', parsed, data);
+		}, 'DELETE FAILED', parsed, data);
+		callback();
+		return;
+	}
+	if (mailbox['special-use']) {
+		connection.send({
+			tag: parsed.tag,
+			command: 'NO',
+			attributes:[
+				{type: 'TEXT', value: 'Cannot delete special mailboxes!'}
+			]
+		}, 'DELETE FAILED', parsed, data);
 		callback();
 		return;
 
 	}
 
-	connection.storage.create_folder(connection.user, path, function(){
+	connection.storage.delete_folder(connection.user, path, function(){
 
 		connection.indexFolders(function(){
 
-			connection.send({
-				tag: parsed.tag,
-				command: 'OK',
-				attributes: [
-					{type: 'TEXT', value: 'completed'}
-				]
-			}, 'CREATE', parsed, data);
 
 		});
+
+		connection.send({
+			tag: parsed.tag,
+			command: 'OK',
+			attributes: [
+				{type: 'TEXT', value: 'completed'}
+			]
+		}, 'DELETE', parsed, data);
 
 	})
 

--- a/lib/commands/rename.js
+++ b/lib/commands/rename.js
@@ -1,0 +1,83 @@
+'use strict';
+
+module.exports = function(connection, parsed, data, callback) {
+
+	if (!parsed.attributes ||
+		parsed.attributes.length != 2 ||
+		!parsed.attributes[0] ||
+		!parsed.attributes[1]
+	) {
+
+		connection.send({
+			tag: parsed.tag,
+			command: 'BAD',
+			attributes:[
+				{type: 'TEXT', value: 'RENAME expects 1 mailbox name'}
+			]
+		}, 'INVALID COMMAND', parsed, data);
+		callback();
+		return;
+	}
+
+	if (['Authenticated', 'Selected'].indexOf(connection.state) < 0) {
+		connection.send({
+			tag: parsed.tag,
+			command: 'BAD',
+			attributes:[
+				{type: 'TEXT', value: 'Log in first'}
+			]
+		}, 'RENAME FAILED', parsed, data);
+		callback();
+		return;
+	}
+
+	var oldPath = parsed.attributes[0].value,
+		oldMailbox = connection.getMailbox(oldPath);
+
+	var newPath = parsed.attributes[1].value,
+		newMailbox = connection.getMailbox(newPath);
+
+
+	if (!oldMailbox) {
+		connection.send({
+			tag: parsed.tag,
+			command: 'NO',
+			attributes:[
+				{type: 'TEXT', value: 'Mailbox does not exist'}
+			]
+		}, 'RENAME FAILED', parsed, data);
+		callback();
+		return;
+	}
+
+	if (newMailbox) {
+		connection.send({
+			tag: parsed.tag,
+			command: 'NO',
+			attributes:[
+				{type: 'TEXT', value: 'Mailbox already exists'}
+			]
+		}, 'RENAME FAILED', parsed, data);
+		callback();
+		return;
+	}
+
+	connection.storage.rename_folder(connection.user, oldPath, newPath, function(){
+
+		connection.indexFolders(function(){
+
+			connection.send({
+				tag: parsed.tag,
+				command: 'OK',
+				attributes: [
+					{type: 'TEXT', value: 'completed'}
+				]
+			}, 'RENAME', parsed, data);
+
+		});
+
+	})
+
+
+
+};

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -220,7 +220,7 @@ IMAPConnection.prototype.indexFolders = function(callback) {
 			}
 		}
 	}
-    me.folders = deepExtend(userFolders, this.options.folders);
+    me.folders = deepExtend({}, userFolders, this.options.folders);
     me.folderCache = {};
     var walk_tree_count = 0;
     function walk_tree(path, separator, branch, namespace, alter_walk_tree) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -392,7 +392,7 @@ IMAPConnection.prototype.onNotify = function(notification) {
 };
 
 IMAPConnection.prototype.onAuthenticated = function(notification) {
-	this.indexFolders();
+	this.indexFolders(function(){});
 };
 
 IMAPConnection.prototype.upgradeConnection = function(callback) {


### PR DESCRIPTION
This allows one to use their mail client to perform CRUD operations on folders.

You will need to add this to your storage implementation though:

``` javascript

MongoDecorator.prototype.create_folder = function(user, folder, callback) {

    user.folders[folder] = {
        type:'personal',
        created: new Date()
    };

    this._users.update({
        _id: user._id
    }, {
        $set:{
            folders: user.folders
        }
    }, callback);

}

MongoDecorator.prototype.rename_folder = function(user, oldFolder, newFolder, callback) {

    user.folders[newFolder] = user.folders[oldFolder];
    delete user.folders[oldFolder];

    this._users.update({
        _id: user._id
    }, {
        $set:{
            folders: user.folders
        }
    });

    this._messages.update({
        folder: oldFolder
    }, {
        $set:{
            folder: newFolder
        }
    },{
        multi:true
    }, callback);

}

MongoDecorator.prototype.delete_folder = function(user, folder, callback) {

    delete user.folders[folder];

    this._users.update({
        _id: user._id
    }, {
        $set:{
            folders: user.folders
        }
    }, callback);

    this._messages.update({
        folder: folder
    }, {
        $set:{
            folder: '\\Trash'
        }
    },{
        multi:true
    });


}
```
